### PR TITLE
Fixes for new hardened-nginx image

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.0.2"
 description: A Pi-hole over HTTPS Helm chart for Kubernetes
 name: poh
-version: 0.0.2
+version: 0.0.3

--- a/templates/nginx-configMap.yaml
+++ b/templates/nginx-configMap.yaml
@@ -11,11 +11,6 @@ data:
       listen 443 ssl http2;
       listen [::]:443 ssl http2;
 
-      ssl on;
-
-      ssl_certificate /etc/nginx/ssl/cert.pem;
-      ssl_certificate_key /etc/nginx/ssl/key.pem;
-
       server_name _;
 
       set_real_ip_from 0.0.0.0/0;


### PR DESCRIPTION
- Default SSL certificates are defined in nginx configuration.
- `ssl` directive is deprecated